### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/haproxy.js
+++ b/haproxy.js
@@ -1,3 +1,8 @@
+const {Container, Service, publicInternet} = require("@quilt/quilt");
+const fs = require('fs');
+const path = require('path');
+const _ = require('underscore');
+
 var image = "haproxy:1.6.4";
 var configPath = "/usr/local/etc/haproxy/haproxy.cfg";
 
@@ -34,7 +39,7 @@ function Haproxy(n, services, port, balance) {
 };
 
 function buildConfig(addrs, balance) {
-    var config = read("./haproxy.cfg");
+    var config = fs.readFileSync(path.join(__dirname, "haproxy.cfg"), {encoding: 'utf8'});
     config += "\n    balance " + balance;
     for (var i = 0 ; i < addrs.length; i++) {
         config += "\n    server " + i + " " + addrs[i] + " check resolvers dns";

--- a/package.json
+++ b/package.json
@@ -1,3 +1,10 @@
 {
-    "main": "./haproxy.js"
+  "name": "@quilt/haproxy",
+  "version": "0.0.1",
+  "main": "./haproxy.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt",
+    "underscore": "^1.8.3"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.