### PR TITLE
blueprint: Export constructor directly

### DIFF
--- a/haproxy.js
+++ b/haproxy.js
@@ -47,4 +47,4 @@ function buildConfig(addrs, balance) {
     return config;
 }
 
-module.exports.Haproxy = Haproxy;
+module.exports = Haproxy;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilt/haproxy",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "./haproxy.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Most other blueprints export their constructors directly, HAProxy should do the
same for consistency. This way, you don't have to access .Haproxy of the import.
This is a quick fix before merging the larger rewrite, but will be nice for a cleaner
MEAN blueprint for the Node.js Summit presentation.

When this is merged, we should merge:

- https://github.com/quilt/quilt/pull/994
- https://github.com/quilt/django/pull/5
- https://github.com/quilt/wordpress/pull/3
- https://github.com/quilt/mean/pull/5